### PR TITLE
feat: npm package for publishing templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,46 @@
 npm install screwdriver-template-main
 ```
 
+### Validating a template using Screwdriver
+
+Run the `template-validate` script. By default, the path `./sd-template.yaml` will be read. However, a user can specify a custom path using the env variable: `SD_TEMPLATE_PATH`.
+
+To validate multiple templates in the same repo, a template maintainer would use the following pattern in their `screwdriver.yaml`:
+
+```yaml
+shared:
+    image: node:6
+jobs:
+    main:  
+        steps:
+            - install: npm install screwdriver-template-main
+            - validate: ./node_modules/.bin/template-validate
+        environment:
+            SD_TEMPLATE_PATH: ./path/to/template.yaml
+```
+
+### Publishing a template using Screwdriver
+
+Run the `template-publish` script. By default, the path `./sd-template.yaml` will be read. However, a user can specify a custom path using the env variable: `SD_TEMPLATE_PATH`.
+
+To publish multiple templates in the same repo, a template maintainer would use the following pattern in their `screwdriver.yaml`:
+
+```yaml
+shared:
+    image: node:6
+jobs:
+    main:  
+        steps:
+            - install: npm install screwdriver-template-main
+            # this is run by the PRs as well
+            - validate: ./node_modules/.bin/template-validate
+    publish:
+        steps:
+            - install: npm install screwdriver-template-main
+            # publishing also validates
+            - publish: ./node_modules/.bin/template-publish
+```
+
 ## Testing
 
 ```bash
@@ -25,7 +65,7 @@ Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
 [license-image]: https://img.shields.io/npm/l/screwdriver-template-main.svg
 [issues-image]: https://img.shields.io/github/issues/screwdriver-cd/template-main.svg
 [issues-url]: https://github.com/screwdriver-cd/template-main/issues
-[status-image]: https://cd.screwdriver.cd/pipelines/pipelineid/badge
-[status-url]: https://cd.screwdriver.cd/pipelines/pipelineid
+[status-image]: https://cd.screwdriver.cd/pipelines/114/badge
+[status-url]: https://cd.screwdriver.cd/pipelines/114
 [daviddm-image]: https://david-dm.org/screwdriver-cd/template-main.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/screwdriver-cd/template-main

--- a/index.js
+++ b/index.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const request = require('request-promise-native');
+const fs = require('fs');
+const URL = require('url');
+const Yaml = require('js-yaml');
+
+/**
+ * Loads the yaml configuration from a file
+ * @method loadYaml
+ * @param  {String}     path        File path
+ * @return {Promise}    Promise that resolves to the template as a config object
+ */
+function loadYaml(path) {
+    return new Promise(resolve =>
+        resolve(Yaml.safeLoad(fs.readFileSync(path, 'utf8'))));
+}
+
+/**
+ * Validates the template yaml
+ * @method validateTemplate
+ * @param   {Object}        config          Template config
+ * @return {Promise}         Resolves when template is valid/rejects when error or invalid
+ */
+function validateTemplate(config) {
+    const hostname = process.env.SD_API_URL || 'https://api.screwdriver.cd/v4/';
+    const url = URL.resolve(hostname, 'validator/template');
+
+    return request({
+        method: 'POST',
+        url,
+        auth: {
+            bearer: process.env.SD_TOKEN
+        },
+        json: true,
+        body: {
+            yaml: JSON.stringify(config)
+        }
+    }).then((response) => {
+        if (response.errors.length > 0) {
+            let errorMessage = 'Template is not valid for the following reasons:';
+
+            response.errors.forEach((err) => {
+                /* eslint-disable prefer-template */
+                errorMessage += `\n${JSON.stringify(err, null, 4)},`;
+                /* eslint-enable prefer-template */
+            });
+
+            throw new Error(errorMessage);
+        }
+
+        return 'Template is valid';
+    });
+}
+
+/**
+ * Publishes the template yaml by posting to the SDAPI /templates endpoint
+ * @method publishTemplate
+ * @param   {Object}        config          Template config
+ * @return {Promise}        Resolves if publish successfully
+ */
+function publishTemplate(config) {
+    const hostname = process.env.SD_API_URL || 'https://api.screwdriver.cd/v4/';
+    const url = URL.resolve(hostname, 'templates');
+
+    return request({
+        method: 'POST',
+        url,
+        auth: {
+            bearer: process.env.SD_TOKEN
+        },
+        json: true,
+        body: {
+            yaml: JSON.stringify(config)
+        },
+        resolveWithFullResponse: true,
+        simple: false
+    }).then((response) => {
+        const body = response.body;
+
+        if (response.statusCode !== 201) {
+            throw new Error('Error publishing template. ' +
+            `${body.statusCode} (${body.error}): ${body.message}`);
+        }
+
+        return 'Template was successfully published';
+    });
+}
+
+module.exports = {
+    loadYaml,
+    validateTemplate,
+    publishTemplate
+};

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "test": "jenkins-mocha --recursive",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
+  "bin": {
+    "template-publish": "./publish.js",
+    "template-validate": "./validate.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:screwdriver-cd/template-main.git"
@@ -35,9 +39,15 @@
     "chai": "^3.5.0",
     "eslint": "^3.9.1",
     "eslint-config-screwdriver": "^2.0.9",
-    "jenkins-mocha": "^3.0.0"
+    "jenkins-mocha": "^3.0.0",
+    "mockery": "^2.0.0",
+    "sinon": "^2.1.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "js-yaml": "^3.8.3",
+    "request": "^2.81.0",
+    "request-promise-native": "^1.0.3"
+  },
   "release": {
     "debug": false,
     "verifyConditions": {

--- a/publish.js
+++ b/publish.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const index = require('./index');
+const path = process.env.SD_TEMPLATE_PATH || './sd-template.yaml';
+
+return index.loadYaml(path)
+    .then(config => index.publishTemplate(config))
+    .then(console.log)
+    .catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,158 @@
 'use strict';
 
 const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
 
-describe('index test', () => {
-    it('fails', () => {
-        assert.isTrue(false);
+describe('index', () => {
+    let requestMock;
+    let YamlMock;
+    let fsMock;
+    let index;
+    let templateConfig;
+
+    before(() => {
+        mockery.enable({
+            warnOnUnregistered: false,
+            useCleanCache: true
+        });
+    });
+
+    beforeEach(() => {
+        requestMock = sinon.stub();
+        YamlMock = {
+            safeLoad: sinon.stub()
+        };
+        fsMock = {
+            readFileSync: sinon.stub()
+        };
+        templateConfig = {
+            name: 'template/test',
+            version: '1.0.0',
+            description: 'test description',
+            maintainer: 'foo@bar.com',
+            config: {
+                image: 'node:6',
+                steps: [
+                    { publish: 'node ./test.js' }
+                ]
+            }
+        };
+
+        YamlMock.safeLoad.returns(templateConfig);
+
+        mockery.registerMock('fs', fsMock);
+        mockery.registerMock('js-yaml', YamlMock);
+        mockery.registerMock('request-promise-native', requestMock);
+
+        // eslint-disable-next-line global-require
+        index = require('../index');
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+        index = null;
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('Load Yaml', () => {
+        it('resolves if loads successfully', () => {
+            YamlMock.safeLoad.resolves('yamlcontent');
+
+            return index.loadYaml(config => assert.equal(config, 'yamlcontent'));
+        });
+    });
+
+    describe('Template Validate', () => {
+        it('throws error when request yields an error', () => {
+            requestMock.rejects(new Error('error'));
+
+            return index.validateTemplate(templateConfig)
+                .then(() => assert.fail('should not get here'))
+                .catch(err => assert.equal(err.message, 'error'));
+        });
+
+        it('throws error if response template is invalid', () => {
+            const responseFake = {
+                errors: [{
+                    message: '"steps" is required',
+                    path: 'config.steps',
+                    type: 'any.required',
+                    context: {
+                        key: 'steps'
+                    }
+                }],
+                template: {}
+            };
+
+            requestMock.resolves(responseFake);
+
+            return index.validateTemplate(templateConfig)
+                .then(() => assert.fail('should not get here'))
+                .catch(err => assert.equal(
+                    err.message,
+                    'Template is not valid for the following reasons:\n' +
+                    '{\n    "message": "\\"steps\\" is required",\n    "path": "config.steps",' +
+                    '\n    "type": "any.required",' +
+                    '\n    "context": {\n        "key": "steps"\n    }\n},')
+                );
+        });
+
+        it('resolves if template is valid', () => {
+            const responseFake = {
+                errors: [],
+                template: templateConfig
+            };
+
+            requestMock.resolves(responseFake);
+
+            return index.validateTemplate(templateConfig)
+                .then(msg => assert.equal(msg, 'Template is valid'));
+        });
+    });
+
+    describe('Template Publish', () => {
+        it('throws error when request yields an error', () => {
+            requestMock.rejects(new Error('error'));
+
+            return index.publishTemplate(templateConfig)
+                .then(() => assert.fail('should not get here'))
+                .catch(err => assert.equal(err.message, 'error'));
+        });
+
+        it('throws error for the corresponding request error status code if not 201', () => {
+            const responseFake = {
+                statusCode: 403,
+                body: {
+                    statusCode: 403,
+                    error: 'Forbidden',
+                    message: 'Fake forbidden message'
+                }
+            };
+
+            requestMock.resolves(responseFake);
+
+            return index.publishTemplate(templateConfig)
+                .then(() => assert.fail('should not get here'))
+                .catch(err => assert.equal(err.message,
+                    'Error publishing template. 403 (Forbidden): Fake forbidden message')
+                );
+        });
+
+        it('succeeds and does not throw an error if request status code is 201', () => {
+            const responseFake = {
+                statusCode: 201,
+                body: templateConfig
+            };
+
+            requestMock.resolves(responseFake);
+
+            return index.publishTemplate(templateConfig)
+                .then(msg => assert.equal(msg, 'Template was successfully published'));
+        });
     });
 });

--- a/validate.js
+++ b/validate.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const index = require('./index');
+const path = process.env.SD_TEMPLATE_PATH || './sd-template.yaml';
+
+return index.loadYaml(path)
+    .then(config => index.validateTemplate(config))
+    .then(console.log)
+    .catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });


### PR DESCRIPTION
This package provides script to validate and publish templates. 

To validate:
```yaml
shared:
    image: node:6
jobs:
    main:  
        steps:
            - install: npm install screwdriver-template-main
            - validate: ./node_modules/.bin/template-validate
        environment:
            SD_TEMPLATE_PATH: ./path/to/template.yaml
```

To publish: 
```yaml
shared:
    image: node:6
jobs:
    main:  
        steps:
            - install: npm install screwdriver-template-main
            # this is run by the PRs as well
            - validate: ./node_modules/.bin/template-validate
    publish:
        steps:
            - install: npm install screwdriver-template-main
            # publishing also validates
            - publish: ./node_modules/.bin/template-publish
```


Blocked by: https://github.com/screwdriver-cd/screwdriver/pull/520
Related: https://github.com/screwdriver-cd/screwdriver/issues/470