### PR TITLE
[WIP] Validate templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,25 @@
 npm install screwdriver-template-main
 ```
 
+### Publishing a template using Screwdriver
+
+To publish a new template, installs the `screwdriver-template-main` npm package, and run the `template-publish` script. By default, the path `./sd-template.yaml` will be read. However, a user can specify a custom path using the env variable: `SD_TEMPLATE_PATH`.
+
+To publish multiple templates in the same repo, a template maintainer would use the following pattern in their `screwdriver.yaml`:
+
+```yaml
+shared:
+    image: node:6
+jobs:
+    main:  
+        steps:
+            - install: npm install screwdriver-template-main
+            - publish: ./node_modules/.bin/template-publish
+        environment:
+            SD_TEMPLATE_PATH: ./path/to/template.yaml
+```
+
+
 ## Testing
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -38,6 +38,48 @@ function publishTemplate() {
         .catch(err => Promise.reject(err.message));
 }
 
+/**
+ * Validates the template yaml by posting to the SDAPI /validator/template endpoint
+ * @method validateTemplate
+ * @return {Request}         Request object from post call to SDAPI
+ */
+function validateTemplate() {
+    let i;
+    let errorMessage;
+
+    const path = process.env.SD_TEMPLATE_PATH || './sd-template.yaml';
+    const json = JSON.stringify(Yaml.safeLoad(fs.readFileSync(path, 'utf8')));
+    const params = {
+        body: {
+            yaml: json
+        },
+        json: true,
+        auth: {
+            bearer: process.env.SD_TOKEN
+        },
+        method: 'POST',
+        url: 'https://api.screwdriver.cd/v4/validator/template'
+    };
+
+    return request(params, (err, response, body) => {
+        if (err) {
+            throw new Error(`Error sending validate request: ${err}`);
+        } else if (body.errors.length > 0) {
+            errorMessage = 'Template is not valid for the following reasons:';
+            for (i = 0; i < body.errors.length; i += 1) {
+                /* eslint-disable prefer-template */
+                errorMessage += `\n ${JSON.stringify(body.errors[i], null, 3)}`;
+                /* eslint-enable prefer-template */
+            }
+
+            throw new Error(errorMessage);
+        } else {
+            console.log('Template is valid.');
+        }
+    }).headers;
+}
+
 module.exports = {
-    publishTemplate
+    publishTemplate,
+    validateTemplate
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const request = require('request');
+const request = require('request-promise');
 const fs = require('fs');
 const Yaml = require('js-yaml');
 
@@ -19,21 +19,23 @@ function publishTemplate() {
             bearer: process.env.SD_TOKEN
         },
         method: 'POST',
-        url: 'https://api.screwdriver.cd:443/v4/templates'
+        url: 'https://api.screwdriver.cd/v4/templates',
+        resolveWithFullResponse: true,
+        simple: false
     };
 
-    request(params, (err, response, body) => {
-        if (err) {
-            throw new Error(`Error sending request: ${err}`);
-        } else if (response.statusCode !== 201) {
-            throw new Error('Template was not published. ' +
-                `${body.statusCode} (${body.error}): ${body.message}`);
-        } else {
-            console.log('Template successfully published.');
-        }
-    });
+    return request(params)
+        .then((response) => {
+            const body = response.body;
 
-    return null;
+            if (response.statusCode !== 201) {
+                throw new Error('Template was not published. ' +
+                `${body.statusCode} (${body.error}): ${body.message}`);
+            }
+
+            return Promise.resolve('Template successfully published.');
+        })
+        .catch(err => Promise.reject(err.message));
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const request = require('request');
+const fs = require('fs');
+const Yaml = require('js-yaml');
+
+/**
+ * Publishes the template yaml by posting to the SDAPI /templates endpoint
+ * @method publishTemplate
+ * @return {null}
+ */
+function publishTemplate() {
+    const path = process.env.SD_TEMPLATE_PATH || './sd-template.yaml';
+    const yaml = Yaml.safeLoad(fs.readFileSync(path, 'utf8'));
+    const params = {
+        body: yaml,
+        json: true,
+        auth: {
+            bearer: process.env.SD_TOKEN
+        },
+        method: 'POST',
+        url: 'https://api.screwdriver.cd:443/v4/templates'
+    };
+
+    request(params, (err, response, body) => {
+        if (err) {
+            throw new Error(`Error sending request: ${err}`);
+        } else if (response.statusCode !== 201) {
+            throw new Error('Template was not published. ' +
+                `${body.statusCode} (${body.error}): ${body.message}`);
+        } else {
+            console.log('Template successfully published.');
+        }
+    });
+
+    return null;
+}
+
+module.exports = {
+    publishTemplate
+};

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "js-yaml": "^3.8.3",
-    "request": "^2.81.0"
+    "request-promise": "^4.2.0"
   },
   "release": {
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "bin": {
-    "template-publish": "./publish.js"
+    "template-publish": "./publish.js",
+    "template-validate": "./validate.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "test": "jenkins-mocha --recursive",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
+  "bin": {
+    "template-publish": "./publish.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:screwdriver-cd/template-main.git"
@@ -35,9 +38,14 @@
     "chai": "^3.5.0",
     "eslint": "^3.9.1",
     "eslint-config-screwdriver": "^2.0.9",
-    "jenkins-mocha": "^3.0.0"
+    "jenkins-mocha": "^3.0.0",
+    "mockery": "^2.0.0",
+    "sinon": "^2.1.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "js-yaml": "^3.8.3",
+    "request": "^2.81.0"
+  },
   "release": {
     "debug": false,
     "verifyConditions": {

--- a/publish.js
+++ b/publish.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const index = require('./index');
+
+index.publishTemplate();

--- a/publish.js
+++ b/publish.js
@@ -2,6 +2,9 @@
 
 'use strict';
 
-const index = require('./index');
-
-index.publishTemplate();
+require('./index').publishTemplate()
+    .then(console.log)
+    .catch((err) => {
+        console.log(err);
+        process.exit(1);
+    });

--- a/sd-template.yaml
+++ b/sd-template.yaml
@@ -1,8 +1,0 @@
-name: template/test
-version: 1.0.0
-description: Publishes the template yaml from sd-template.yaml
-maintainer: tiffanykyi@gmail.com
-config:
-    image: node:6
-    steps:
-        - publish: node ./publish.js

--- a/sd-template.yaml
+++ b/sd-template.yaml
@@ -1,0 +1,8 @@
+name: template/test
+version: 1.0.0
+description: Publishes the template yaml from sd-template.yaml
+maintainer: tiffanykyi@gmail.com
+config:
+    image: node:6
+    steps:
+        - publish: node ./publish.js

--- a/test/data/template_invalid.txt
+++ b/test/data/template_invalid.txt
@@ -1,0 +1,18 @@
+Template is not valid for the following reasons:
+ {
+   "message": "\"steps\" is required",
+   "path": "config.steps",
+   "type": "any.required",
+   "context": {
+      "key": "steps"
+   }
+}
+ {
+   "message": "\"doesntexist\" is not allowed",
+   "path": "doesntexist",
+   "type": "object.allowUnknown",
+   "context": {
+      "child": "doesntexist",
+      "key": "doesntexist"
+   }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,94 @@
 'use strict';
 
 const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
 
-describe('index test', () => {
-    it('fails', () => {
-        assert.isTrue(false);
+describe('Template Publish', () => {
+    let requestMock;
+    let YamlMock;
+    let fsMock;
+    let index;
+    let yamlReturn;
+
+    before(() => {
+        mockery.enable({
+            warnOnUnregistered: false,
+            useCleanCache: true
+        });
+    });
+
+    beforeEach(() => {
+        requestMock = sinon.stub();
+        YamlMock = {
+            safeLoad: sinon.stub()
+        };
+        fsMock = {
+            readFileSync: sinon.stub()
+        };
+        yamlReturn = {
+            name: 'template/test',
+            version: '1.0.0',
+            description: 'Publishes the template yaml from sd-template.yaml',
+            maintainer: 'tiffanykyi@gmail.com',
+            config: {
+                image: 'node:6',
+                steps: [
+                    { publish: 'node ./publish.js' }
+                ]
+            }
+        };
+
+        YamlMock.safeLoad.returns(yamlReturn);
+
+        mockery.registerMock('fs', fsMock);
+        mockery.registerMock('js-yaml', YamlMock);
+        mockery.registerMock('request', requestMock);
+
+        /* eslint-disable global-require */
+        index = require('../index');
+        /* eslint-enable global-require */
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+        index = null;
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('throws error when request yields an error', () => {
+        const error = new Error('error');
+
+        requestMock.yields(error);
+        assert.throws(index.publishTemplate, Error, 'Error sending request: Error: error');
+    });
+
+    it('throws error for the corresponding request error status code if not 201', () => {
+        const responseFake = {
+            statusCode: 403,
+            body: {
+                statusCode: 403,
+                error: 'Forbidden',
+                message: 'Fake forbidden message'
+            }
+        };
+
+        requestMock.yields(null, responseFake, responseFake.body);
+        assert.throws(index.publishTemplate, Error,
+            'Template was not published. 403 (Forbidden): Fake forbidden message');
+    });
+
+    it('succeeds and does not throw an error if request status code is 201', () => {
+        const responseFake = {
+            statusCode: 201,
+            body: yamlReturn
+        };
+
+        requestMock.yields(null, responseFake, responseFake.body);
+        assert.doesNotThrow(index.publishTemplate);
     });
 });

--- a/validate.js
+++ b/validate.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('./index').validateTemplate()
+    .then(res => console.log(res))
+    .catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });


### PR DESCRIPTION
Prior to the `publishTemplate()` function in #2, this will validate a template using the `data-schema`. If the template is valid, no errors are thrown and 'Template is valid.' will be logged. If there are errors, the error message will print each validation error object after a generic message:

```
Template is not valid for the following reasons:
 {
   "message": "\"steps\" is required",
   "path": "config.steps",
   "type": "any.required",
   "context": {
      "key": "steps"
   }
}
 {
   "message": "\"doesntexist\" is not allowed",
   "path": "doesntexist",
   "type": "object.allowUnknown",
   "context": {
      "child": "doesntexist",
      "key": "doesntexist"
   }
}
```

Currently, this uses the same method as #2 to find the template that needs to be validated. This is under ongoing discussion.

BLOCKED BY: https://github.com/screwdriver-cd/data-schema/pull/118 and https://github.com/screwdriver-cd/template-main/pull/2