### PR TITLE
fix(529): publish should show name and version that get published

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function publishTemplate(config) {
             `${body.statusCode} (${body.error}): ${body.message}`);
         }
 
-        return 'Template was successfully published';
+        return `Template ${body.name}@${body.version} was successfully published`;
     });
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -152,7 +152,8 @@ describe('index', () => {
             requestMock.resolves(responseFake);
 
             return index.publishTemplate(templateConfig)
-                .then(msg => assert.equal(msg, 'Template was successfully published'));
+                .then(msg => assert.equal(msg, 'Template ' +
+                    `${templateConfig.name}@${templateConfig.version} was successfully published`));
         });
     });
 });


### PR DESCRIPTION
Previously, after template gets published, it will just show `Template was successfully published` in the log.
To provide more info, changed it to:
`Template template/test@1.0.0 was successfully published`

Related to: https://github.com/screwdriver-cd/screwdriver/issues/529