### PR TITLE
feat(616): Add script to tag templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,28 @@ jobs:
         steps:
             - install: npm install screwdriver-template-main
             - publish: ./node_modules/.bin/template-publish
-        
+```
+
+### Tagging a template
+
+Optionally, tag a template using the `template-tag` script. This must be done in the same pipeline that published the template. You'll need to add arguments for the template name, tag, and version. The version must be an exact version, not just a major or major.minor one.
+
+Example `screwdriver.yaml` with validation and publishing and tagging:
+
+```yaml
+shared:
+    image: node:6
+jobs:
+    # the main job is run in pull requests as well
+    main:  
+        steps:
+            - install: npm install screwdriver-template-main
+            - validate: ./node_modules/.bin/template-validate
+    publish:
+        steps:
+            - install: npm install screwdriver-template-main
+            - publish: ./node_modules/.bin/template-publish
+            - tag: ./node_modules/.bin/template-tag --name templateName --version 1.2.3 --tag stable
 ```
 
 Create a Screwdriver pipeline with your template repo and start the build to validate and publish it.

--- a/index.js
+++ b/index.js
@@ -87,8 +87,48 @@ function publishTemplate(config) {
     });
 }
 
+/**
+ * Tags a specific template version by posting to the SDAPI /templates/templateName/tag endpoint
+ * @method tagTemplate
+ * @param  {Object}    config
+ * @param  {String}    config.name    Template name
+ * @param  {String}    config.tag     Template tag
+ * @param  {String}    config.version Template version
+ * @return {Promise}                  Resolves if tagged successfully
+ */
+function tagTemplate({ name, tag, version }) {
+    const hostname = process.env.SD_API_URL || 'https://api.screwdriver.cd/v4/';
+    const templateName = encodeURIComponent(name);
+    const templateTag = encodeURIComponent(tag);
+    const url = URL.resolve(hostname, `templates/${templateName}/${templateTag}`);
+
+    return request({
+        method: 'PUT',
+        url,
+        auth: {
+            bearer: process.env.SD_TOKEN
+        },
+        json: true,
+        body: {
+            version
+        },
+        resolveWithFullResponse: true,
+        simple: false
+    }).then((response) => {
+        const body = response.body;
+
+        if (response.statusCode !== 201) {
+            throw new Error('Error tagging template. ' +
+            `${body.statusCode} (${body.error}): ${body.message}`);
+        }
+
+        return `Template ${body.name}@${body.version} was successfully tagged as ${tag}`;
+    });
+}
+
 module.exports = {
     loadYaml,
     validateTemplate,
-    publishTemplate
+    publishTemplate,
+    tagTemplate
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "screwdriver-template-main",
   "version": "0.0.1",
-  "description": "Validates and publishes templates",
+  "description": "Validates, publishes, and tags templates",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
@@ -10,7 +10,8 @@
   },
   "bin": {
     "template-publish": "./publish.js",
-    "template-validate": "./validate.js"
+    "template-validate": "./validate.js",
+    "template-tag": "./tag.js"
   },
   "repository": {
     "type": "git",
@@ -45,6 +46,7 @@
   },
   "dependencies": {
     "js-yaml": "^3.8.3",
+    "nomnom": "^1.8.1",
     "request": "^2.81.0",
     "request-promise-native": "^1.0.3"
   },

--- a/tag.js
+++ b/tag.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const index = require('./index');
+const nomnom = require('nomnom');
+const opts = nomnom
+    .option('name', {
+        required: true,
+        abbr: 'n',
+        help: 'Template name'
+    })
+    .option('tag', {
+        abbr: 't',
+        required: true,
+        help: 'Tag name'
+    })
+    .option('version', {
+        abbr: 'v',
+        required: true,
+        help: 'Tag version'
+    })
+    .parse();
+
+return index.tagTemplate({
+    name: opts.name,
+    tag: opts.tag,
+    version: opts.version
+})
+.then(console.log)
+.catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Context

Users should have an easy way to tag their templates. Currently, the only way to do so is by writing your own script to hit the API.

## Objective

This PR will add a script for tagging templates.

## Related Links

https://github.com/screwdriver-cd/screwdriver/issues/616