### PR TITLE
fix(616): Make file executable

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ function tagTemplate({ name, tag, version }) {
     const hostname = process.env.SD_API_URL || 'https://api.screwdriver.cd/v4/';
     const templateName = encodeURIComponent(name);
     const templateTag = encodeURIComponent(tag);
-    const url = URL.resolve(hostname, `templates/${templateName}/${templateTag}`);
+    const url = URL.resolve(hostname, `templates/${templateName}/tags/${templateTag}`);
 
     return request({
         method: 'PUT',

--- a/tag.js
+++ b/tag.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 'use strict';
 
 const index = require('./index');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -214,7 +214,7 @@ describe('index', () => {
                     `${config.name}@${config.version} was successfully tagged as ${config.tag}`);
                     assert.calledWith(requestMock, {
                         method: 'PUT',
-                        url: 'https://api.screwdriver.cd/v4/templates/template%2Ftest/stable',
+                        url: 'https://api.screwdriver.cd/v4/templates/template%2Ftest/tags/stable',
                         auth: {
                             bearer: process.env.SD_TOKEN
                         },


### PR DESCRIPTION
Need to add `#!/usr/bin/env node` and make file executable.

Running into error:
```
17:01:20
$ ./node_modules/.bin/template-tag --name tifftemplate --version 1.0.3 --tag latest
17:01:20
./node_modules/.bin/template-tag: 1: ./node_modules/.bin/template-tag: use strict: not found
17:01:20
./node_modules/.bin/template-tag: 3: ./node_modules/.bin/template-tag: Syntax error: "(" unexpected
```

Also probably want to use the right endpoint `/templates/{templateName}/tags/{tagName}` (https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/templates/createTag.js#L14)


Related to: https://github.com/screwdriver-cd/template-main/pull/8
Issue: https://github.com/screwdriver-cd/screwdriver/issues/616