### PR TITLE
fix(616): Updating a tag should not throw an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function publishTemplate(config) {
 
         if (response.statusCode !== 201) {
             throw new Error('Error publishing template. ' +
-            `${body.statusCode} (${body.error}): ${body.message}`);
+            `${response.statusCode} (${body.error}): ${body.message}`);
         }
 
         return `Template ${body.name}@${body.version} was successfully published`;
@@ -117,9 +117,9 @@ function tagTemplate({ name, tag, version }) {
     }).then((response) => {
         const body = response.body;
 
-        if (response.statusCode !== 201) {
+        if (response.statusCode !== 201 && response.statusCode !== 200) {
             throw new Error('Error tagging template. ' +
-            `${body.statusCode} (${body.error}): ${body.message}`);
+            `${response.statusCode} (${body.error}): ${body.message}`);
         }
 
         return `Template ${body.name}@${body.version} was successfully tagged as ${tag}`;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -227,5 +227,33 @@ describe('index', () => {
                     });
                 });
         });
+
+        it('succeeds and does not throw an error if request status code is 200', () => {
+            const responseFake = {
+                statusCode: 200,
+                body: templateConfig
+            };
+
+            requestMock.resolves(responseFake);
+
+            return index.tagTemplate(config)
+                .then((msg) => {
+                    assert.equal(msg, 'Template ' +
+                    `${config.name}@${config.version} was successfully tagged as ${config.tag}`);
+                    assert.calledWith(requestMock, {
+                        method: 'PUT',
+                        url: 'https://api.screwdriver.cd/v4/templates/template%2Ftest/tags/stable',
+                        auth: {
+                            bearer: process.env.SD_TOKEN
+                        },
+                        json: true,
+                        body: {
+                            version: '1.0.0'
+                        },
+                        resolveWithFullResponse: true,
+                        simple: false
+                    });
+                });
+        });
     });
 });


### PR DESCRIPTION
Also need to account for the case where the template tag already exists (https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/templates/createTag.js#L57).

Related to: https://github.com/screwdriver-cd/template-main/pull/8, https://github.com/screwdriver-cd/template-main/pull/9
Issue: https://github.com/screwdriver-cd/screwdriver/issues/616