### PR TITLE
feat: Support json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ jobs:
             SD_TEMPLATE_PATH: ./path/to/template.yaml
 ```
 
+`template-validate` can print a result as json by passing `--json` option to the command.
+
+```
+$ ./node_modules/.bin/template-validate --json
+{"valid":true}
+```
+
 ### Publishing a template
 
 Run the `template-publish` script. By default, the path `./sd-template.yaml` will be read. However, a user can specify a custom path using the env variable: `SD_TEMPLATE_PATH`.
@@ -46,6 +53,13 @@ jobs:
         steps:
             - install: npm install screwdriver-template-main
             - publish: ./node_modules/.bin/template-publish
+```
+
+`template-publish` can print a result as json by passing `--json` option to the command.
+
+```
+$ ./node_modules/.bin/template-publish --json
+{name:"template/foo",version:"1.2.3"}
 ```
 
 ### Tagging a template
@@ -73,6 +87,13 @@ jobs:
 Create a Screwdriver pipeline with your template repo and start the build to validate and publish it.
 
 To update a Screwdriver template, make changes in your SCM repository and rerun the pipeline build.
+
+`template-validate` can print a result as json by passing `--json` option to the command.
+
+```
+$ ./node_modules/.bin/template-publish --json --name templateName --version 1.2.3 --tag stable
+{"name":"templateName","tag":"stable","version":"1.2.3"}
+```
 
 ## Testing
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,9 @@ function validateTemplate(config) {
             throw new Error(errorMessage);
         }
 
-        return 'Template is valid';
+        return {
+            valid: true
+        };
     });
 }
 
@@ -83,7 +85,10 @@ function publishTemplate(config) {
             `${response.statusCode} (${body.error}): ${body.message}`);
         }
 
-        return `Template ${body.name}@${body.version} was successfully published`;
+        return {
+            name: body.name,
+            version: body.version
+        };
     });
 }
 
@@ -122,7 +127,11 @@ function tagTemplate({ name, tag, version }) {
             `${response.statusCode} (${body.error}): ${body.message}`);
         }
 
-        return `Template ${body.name}@${body.version} was successfully tagged as ${tag}`;
+        return {
+            name,
+            tag,
+            version
+        };
     });
 }
 

--- a/publish.js
+++ b/publish.js
@@ -3,11 +3,25 @@
 'use strict';
 
 const index = require('./index');
+const nomnom = require('nomnom');
 const path = process.env.SD_TEMPLATE_PATH || './sd-template.yaml';
+const opts = nomnom
+    .option('json', {
+        abbr: 'j',
+        flag: true,
+        help: 'Output result as json'
+    })
+    .parse();
 
 return index.loadYaml(path)
     .then(config => index.publishTemplate(config))
-    .then(console.log)
+    .then((result) => {
+        if (!opts.json) {
+            console.log(`Template ${result.name}@${result.version} was successfully published`);
+        } else {
+            console.log(JSON.stringify(result));
+        }
+    })
     .catch((err) => {
         console.error(err);
         process.exit(1);

--- a/tag.js
+++ b/tag.js
@@ -20,6 +20,11 @@ const opts = nomnom
         required: true,
         help: 'Tag version'
     })
+    .option('json', {
+        abbr: 'j',
+        flag: true,
+        help: 'Output result as json'
+    })
     .parse();
 
 return index.tagTemplate({
@@ -27,7 +32,15 @@ return index.tagTemplate({
     tag: opts.tag,
     version: opts.version
 })
-.then(console.log)
+.then((result) => {
+    if (!opts.json) {
+        console.log(
+            `Template ${result.name}@${result.version} was successfully tagged as ${result.tag}`
+        );
+    } else {
+        console.log(JSON.stringify(result));
+    }
+})
 .catch((err) => {
     console.error(err);
     process.exit(1);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -114,7 +114,9 @@ describe('index', () => {
             requestMock.resolves(responseFake);
 
             return index.validateTemplate(templateConfig)
-                .then(msg => assert.equal(msg, 'Template is valid'));
+                .then(result => assert.deepEqual(result, {
+                    valid: true
+                }));
         });
     });
 
@@ -158,8 +160,10 @@ describe('index', () => {
             requestMock.resolves(responseFake);
 
             return index.publishTemplate(templateConfig)
-                .then(msg => assert.equal(msg, 'Template ' +
-                    `${templateConfig.name}@${templateConfig.version} was successfully published`));
+                .then(result => assert.deepEqual(result, {
+                    name: templateConfig.name,
+                    version: templateConfig.version
+                }));
         });
     });
 
@@ -209,9 +213,12 @@ describe('index', () => {
             requestMock.resolves(responseFake);
 
             return index.tagTemplate(config)
-                .then((msg) => {
-                    assert.equal(msg, 'Template ' +
-                    `${config.name}@${config.version} was successfully tagged as ${config.tag}`);
+                .then((result) => {
+                    assert.deepEqual(result, {
+                        name: config.name,
+                        tag: config.tag,
+                        version: config.version
+                    });
                     assert.calledWith(requestMock, {
                         method: 'PUT',
                         url: 'https://api.screwdriver.cd/v4/templates/template%2Ftest/tags/stable',
@@ -237,9 +244,12 @@ describe('index', () => {
             requestMock.resolves(responseFake);
 
             return index.tagTemplate(config)
-                .then((msg) => {
-                    assert.equal(msg, 'Template ' +
-                    `${config.name}@${config.version} was successfully tagged as ${config.tag}`);
+                .then((result) => {
+                    assert.deepEqual(result, {
+                        name: config.name,
+                        version: config.version,
+                        tag: config.tag
+                    });
                     assert.calledWith(requestMock, {
                         method: 'PUT',
                         url: 'https://api.screwdriver.cd/v4/templates/template%2Ftest/tags/stable',

--- a/validate.js
+++ b/validate.js
@@ -3,11 +3,25 @@
 'use strict';
 
 const index = require('./index');
+const nomnom = require('nomnom');
 const path = process.env.SD_TEMPLATE_PATH || './sd-template.yaml';
+const opts = nomnom
+    .option('json', {
+        abbr: 'j',
+        flag: true,
+        help: 'Output result as json'
+    })
+    .parse();
 
 return index.loadYaml(path)
     .then(config => index.validateTemplate(config))
-    .then(console.log)
+    .then((result) => {
+        if (!opts.json) {
+            console.log('Template is valid');
+        } else {
+            console.log(JSON.stringify(result));
+        }
+    })
     .catch((err) => {
         console.error(err);
         process.exit(1);


### PR DESCRIPTION
# Context
Current publish template outputs a message like `Template foo@1.0.0 was successfully published` but it's not program-friendly. 

# Objective
I added a support for json output to each templates so that users can easily parse it via `jq` and use it in following steps.

```
$ template-publish --json
{"name":"test","version":"1.2.3"}

$ template-publish
Template test@1.2.3 was successfully published
```
Use cases:
```
$ template-publish --json | jq -r .version | meta set step.version -f -
```
```
$ STEP_INFO=$(template-publish --json)
$ template-tag --name $(echo $STEP_INFO | jq -r .name) --version $(echo $STEP_INFO | jq -r .version) --tag latest
```