### PR TITLE
feat: Automatically tag latest version if no version specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#true template-main
+# template-main
 [![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url] [![Dependency Status][daviddm-image]][daviddm-url] ![License][license-image]
 
 > Validates and publishes templates

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# template-main
+#true template-main
 [![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url] [![Dependency Status][daviddm-image]][daviddm-url] ![License][license-image]
 
 > Validates and publishes templates
@@ -103,7 +103,7 @@ $ ./node_modules/.bin/template-remove --json --name templateName
 
 ### Tagging a template
 
-Optionally, tag a template using the `template-tag` script. This must be done in the same pipeline that published the template. You'll need to add arguments for the template name, version, and tag. The version must be an exact version, not just a major or major.minor one.
+Optionally, tag a template using the `template-tag` script. This must be done in the same pipeline that published the template. You'll need to add arguments for the template name and tag. You can optionally specify a version; the version must be an exact version, not just a major or major.minor one. If omitted, the latest version will be tagged.
 
 Example `screwdriver.yaml` with validation and publishing and tagging:
 

--- a/tag.js
+++ b/tag.js
@@ -17,7 +17,7 @@ const opts = nomnom
     })
     .option('version', {
         abbr: 'v',
-        required: true,
+        required: false,
         help: 'Tag version'
     })
     .option('json', {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -315,6 +315,88 @@ describe('index', () => {
                         });
                     });
             });
+
+            it('succeeds when no version number is provided', () => {
+                const versionlessConfig = {
+                    name: config.name,
+                    tag: config.tag
+                };
+                const versionsResponseFake = {
+                    statusCode: 200,
+                    body: [{
+                        id: 23,
+                        labels: [],
+                        config: {
+                            image: 'node:6',
+                            steps: [
+                                {
+                                    echo: 'echo $FOO'
+                                }
+                            ],
+                            environment: {
+                                FOO: 'bar'
+                            }
+                        },
+                        name: 'tifftemplate',
+                        version: '1.0.0',
+                        description: 'test',
+                        maintainer: 'foo@bar.com',
+                        pipelineId: 113
+                    }]
+                };
+                const resultResponseFake = {
+                    statusCode: 201,
+                    body: templateConfig
+                };
+
+                requestMock.onFirstCall().resolves(versionsResponseFake);
+                requestMock.onSecondCall().resolves(resultResponseFake);
+
+                return index.tagTemplate(versionlessConfig)
+                    .then((result) => {
+                        assert.deepEqual(result, {
+                            name: config.name,
+                            tag: config.tag,
+                            version: config.version
+                        });
+                        assert.calledWith(requestMock, {
+                            method: 'PUT',
+                            url,
+                            auth: {
+                                bearer: process.env.SD_TOKEN
+                            },
+                            json: true,
+                            body: {
+                                version: '1.0.0'
+                            },
+                            resolveWithFullResponse: true,
+                            simple: false
+                        });
+                    });
+            });
+
+            it('throws an error when getting latest template versions doesn\'t yield 200', () => {
+                const versionlessConfig = {
+                    name: config.name,
+                    tag: config.tag
+                };
+                const versionsResponseFake = {
+                    statusCode: 404,
+                    body: {
+                        error: 'Not Found',
+                        message: 'Some 404 message'
+                    }
+                };
+
+                requestMock.resolves(versionsResponseFake);
+
+                return index.tagTemplate(versionlessConfig)
+                    .then(() => assert.fail('should not get here'))
+                    .catch((err) => {
+                        assert.equal(err.message, 'Error getting latest template version. ' +
+                            '404 (Not Found): Some 404 message');
+                    });
+            });
         });
 
         describe('Delete a tag', () => {


### PR DESCRIPTION
## Context

Currently, users must specify the exact version to tag a template. This lack of flexibility makes it difficult to manage tags; by design, the `screwdriver.yaml` **must**<sup>1</sup> be updated to bump a tag to a new template version.

By allowing users to tag the latest version, certain common tasks become trivial:

* Automatically tagging the latest version to `latest`
* Creating a detached job that tags the latest version to an arbitrary tag.

<sup>1</sup> While it is possible to extract the most recent template version via metadata, it doesn't make sense to force every template author to "reinvent the wheel".

## Objective

Allow users to omit the `--version` flag for `template-tag`. If the version is omitted, `template-tag` will tag the most recent version.

Usage:

```bash
$ ./node_modules/.bin/template-tag --name template_name --tag latest