### PR TITLE
fix: Update screwdriver.yaml

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -9,11 +9,8 @@ jobs:
         steps:
             - install: npm install
             - test: npm test
-
     publish:
-        steps:
-            - install: npm install semantic-release
-            - publish: npm run semantic-release
+        template: screwdriver-cd/semantic-release@1.0.2
         secrets:
             # Publishing to NPM
             - NPM_TOKEN

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,15 +1,14 @@
-workflow:
-    - publish
-
 shared:
     image: node:6
 
 jobs:
     main:
+        requires: [~pr, ~commit]
         steps:
             - install: npm install
             - test: npm test
     publish:
+        requires: main
         template: screwdriver-cd/semantic-release@1.0.2
         secrets:
             # Publishing to NPM


### PR DESCRIPTION
Use the `screwdriver-cd/semantic-release@1.0.2` to support `node:6`