### PR TITLE
feat: Get template version from tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,32 @@ $ ./node_modules/.bin/template-remove-tag --json --name templateName --tag stabl
 {"name":"templateName","tag":"stable"}
 ```
 
+## Getting the version from a template tag
+
+To get the version from a template tag, run the `template-get-version-from-tag` binary. This must be done in the same pipeline that published the template. You'll need to add arguments for the template name and tag.
+
+Example `screwdriver.yaml` with validation, publishing and tagging, and getting a version as a detached job:
+
+```yaml
+shared:
+    image: node:6
+    steps:
+        - init: npm install screwdriver-template-main
+jobs:
+    main:
+        requires: [~pr, ~commit]
+        steps:
+            - validate: ./node_modules/.bin/template-validate
+    publish:
+        requires: main
+        steps:
+            - publish: ./node_modules/.bin/template-publish
+            - tag: ./node_modules/.bin/template-tag --name templateName --version 1.0.0 --tag latest
+    detached_get_version_from_tag:
+        steps:
+            - get_version: ./node_modules/.bin/template-get-version-from-tag --name templateName --tag latest
+```
+
 ## Testing
 
 ```bash

--- a/getVersionFromTag.js
+++ b/getVersionFromTag.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const index = require('./index');
+const nomnom = require('nomnom');
+const opts = nomnom
+    .option('name', {
+        required: true,
+        abbr: 'n',
+        help: 'Template name'
+    })
+    .option('tag', {
+        abbr: 't',
+        required: true,
+        help: 'Tag name'
+    })
+    .parse();
+
+return index.getVersionFromTag({
+    name: opts.name,
+    tag: opts.tag
+})
+    .then((result) => {
+        console.log(`${opts.tag} tags ${opts.name}@${result.version}`);
+    })
+    .catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });

--- a/index.js
+++ b/index.js
@@ -157,6 +157,40 @@ function getLatestVersion(name) {
 }
 
 /**
+ * Helper function that returns the version from a tag
+ * @method getVersionFromTag
+ * @param  {String}         name        Template name
+ * @param  {String}         tag         Tag to fetch version from
+ * @return {Promise}        Resolves the version from given tag
+ */
+function getVersionFromTag({ name, tag }) {
+    const hostname = process.env.SD_API_URL || 'https://api.screwdriver.cd/v4/';
+    const templateName = encodeURIComponent(name);
+    const templateTag = encodeURIComponent(tag);
+    const url = URL.resolve(hostname, `templates/${templateName}/${templateTag}`);
+
+    return request({
+        method: 'GET',
+        url,
+        auth: {
+            bearer: process.env.SD_TOKEN
+        },
+        json: true,
+        resolveWithFullResponse: true,
+        simple: false
+    }).then((response) => {
+        const { body, statusCode } = response;
+
+        if (statusCode !== 200) {
+            throw new Error('Error getting version from tag. ' +
+                `${statusCode} (${body.error}): ${body.message}`);
+        }
+
+        return body.version;
+    });
+}
+
+/**
  * Tags a specific template version by posting to the SDAPI /templates/{templateName}/tags/{tagName} endpoint
  * @method tagTemplate
  * @param  {Object}    config
@@ -247,5 +281,6 @@ module.exports = {
     publishTemplate,
     removeTemplate,
     tagTemplate,
-    removeTag
+    removeTag,
+    getVersionFromTag
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "template-validate": "./validate.js",
     "template-remove": "./remove.js",
     "template-tag": "./tag.js",
-    "template-remove-tag": "./removeTag.js"
+    "template-remove-tag": "./removeTag.js",
+    "template-get-version-from-tag": "./getVersionFromTag.js"
   },
   "repository": {
     "type": "git",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -399,6 +399,50 @@ describe('index', () => {
             });
         });
 
+        describe('Get version from a tag', () => {
+            const config = {
+                name: 'template/test',
+                tag: 'stable'
+            };
+
+            it('throws error when request yields an error', () => {
+                requestMock.rejects(new Error('error'));
+
+                return index.getVersionFromTag(config)
+                    .then(() => assert.fail('should not get here'))
+                    .catch((err) => {
+                        assert.equal(err.message, 'error');
+                    });
+            });
+
+            it('succeeds and does not throw an error if request status code is 200', () => {
+                const versionUrl = `${process.env.SD_API_URL || 'https://api.screwdriver.cd/v4/'}`
+                    + 'templates/template%2Ftest/stable';
+
+                const responseFake = {
+                    statusCode: 200,
+                    body: templateConfig
+                };
+
+                requestMock.resolves(responseFake);
+
+                return index.getVersionFromTag(config)
+                    .then((result) => {
+                        assert.deepEqual(result, templateConfig.version);
+                        assert.calledWith(requestMock, {
+                            method: 'GET',
+                            url: versionUrl,
+                            auth: {
+                                bearer: process.env.SD_TOKEN
+                            },
+                            json: true,
+                            resolveWithFullResponse: true,
+                            simple: false
+                        });
+                    });
+            });
+        });
+
         describe('Delete a tag', () => {
             const config = {
                 name: 'template/test',


### PR DESCRIPTION
Add a route to retrieve the template version from a tag using the endpoint https://api.screwdriver.cd/v4/documentation#!/v4/getV4TemplatesNameVersionortag.

This will allow me to do promotion of template versions, e.g. publish template `1.0.0` as `latest`, and then, in a later job, promote `1.0.0` from `latest` to `stable`. Otherwise, if `tag` could support this innately and take a `fromTag` argument, that would also work.