### PR TITLE
fix: return only the version for getVersionFromTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ $ ./node_modules/.bin/template-remove-tag --json --name templateName --tag stabl
 {"name":"templateName","tag":"stable"}
 ```
 
-## Getting the version from a template tag
+### Getting the version from a template tag
 
 To get the version from a template tag, run the `template-get-version-from-tag` binary. This must be done in the same pipeline that published the template. You'll need to add arguments for the template name and tag.
 

--- a/getVersionFromTag.js
+++ b/getVersionFromTag.js
@@ -22,7 +22,7 @@ return index.getVersionFromTag({
     tag: opts.tag
 })
     .then((result) => {
-        console.log(`${opts.tag} tags ${opts.name}@${result.version}`);
+        console.log(`${result}`);
     })
     .catch((err) => {
         console.error(err);


### PR DESCRIPTION
`template-get-version-from-tag` should just return the version number so I don't have to parse the rest of the message to get it.

Also fix the heading level for the README.