### PR TITLE
feat: [small] add template tag when publishing template

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -11,13 +11,24 @@ const opts = nomnom
         flag: true,
         help: 'Output result as json'
     })
+    .option('tag', {
+        abbr: 't',
+        default: 'latest',
+        help: 'Add template tag'
+    })
     .parse();
 
 return index.loadYaml(path)
     .then(config => index.publishTemplate(config))
+    .then(publishResult => index.tagTemplate({
+        name: publishResult.name,
+        tag: opts.tag,
+        version: publishResult.version
+    }))
     .then((result) => {
         if (!opts.json) {
-            console.log(`Template ${result.name}@${result.version} was successfully published`);
+            console.log(`Template ${result.name}@${result.version} was `
+                + `successfully published and tagged as ${result.tag}`);
         } else {
             console.log(JSON.stringify(result));
         }


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Like sd-cmd promote, template tag should be added when publishing template.
I add tag option to template-publish.

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
Add tag option to template-publish. The default tag value is `latest`.

