### PR TITLE
fix: template-remove command

### DIFF
--- a/bin/remove.js
+++ b/bin/remove.js
@@ -2,4 +2,4 @@
 
 'use strict';
 
-require('../commands').run('remove');
+require('../commands').run('remove_template');

--- a/commands.js
+++ b/commands.js
@@ -119,7 +119,7 @@ const operations = {
         help: 'remove tag'
     },
 
-    /* remove a tamplte */
+    /* remove a template */
     remove_template: {
         opts: {
             name: { required: true, abbr: 'n', help: 'Template name' },


### PR DESCRIPTION
## Context

`template-remove` script would throw `TypeError: Cannot read property 'opts' of undefined`.

## Objective

Make `template-remove` script work correctly.

## References

#25 Refactor command-line tools.

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
