### PR TITLE
fix(1961): Validatetemplate returns full response

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,10 +35,12 @@ function validateTemplate(config) {
             yaml: JSON.stringify(config)
         }
     }).then(response => {
-        if (response.errors.length > 0) {
+        const { body } = response;
+
+        if (body.errors.length > 0) {
             let errorMessage = 'Template is not valid for the following reasons:';
 
-            response.errors.forEach(err => {
+            body.errors.forEach(err => {
                 /* eslint-disable prefer-template */
                 errorMessage += `\n${JSON.stringify(err, null, 4)},`;
                 /* eslint-enable prefer-template */

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -81,17 +81,19 @@ describe('index', () => {
 
         it('throws error if response template is invalid', () => {
             const responseFake = {
-                errors: [
-                    {
-                        message: '"steps" is required',
-                        path: 'config.steps',
-                        type: 'any.required',
-                        context: {
-                            key: 'steps'
+                body: {
+                    errors: [
+                        {
+                            message: '"steps" is required',
+                            path: 'config.steps',
+                            type: 'any.required',
+                            context: {
+                                key: 'steps'
+                            }
                         }
-                    }
-                ],
-                template: {}
+                    ],
+                    template: {}
+                }
             };
 
             requestMock.resolves(responseFake);
@@ -114,8 +116,10 @@ describe('index', () => {
 
         it('resolves if template is valid', () => {
             const responseFake = {
-                errors: [],
-                template: templateConfig
+                body: {
+                    errors: [],
+                    template: templateConfig
+                }
             };
 
             requestMock.resolves(responseFake);


### PR DESCRIPTION
## Context

Validate template used to return response body only. The new screwdriver-request package returns full response.

## Objective

This PR fixes validateTemplate to get `errors` from response body.
## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1961
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
