### PR TITLE
fix(2687): Update package.json to reflect node version requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "screwdriver-template-main",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Validates, publishes, and tags templates",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true"
   },
   "bin": {
     "sd-template-tool": "./bin/main.js",
@@ -19,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/template-main.git"
+    "url": "git+https://github.com/screwdriver-cd/template-main.git"
   },
   "homepage": "https://github.com/screwdriver-cd/template-main",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
@@ -58,9 +57,9 @@
     "screwdriver-request": "^1.0.1"
   },
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
+  },
+  "engines": {
+    "node": ">=14.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
     "debug": false
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=12.0.0"
   }
 }

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:14
+    image: node:12
 
 jobs:
     main:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:12
+    image: node:14
 
 jobs:
     main:


### PR DESCRIPTION
## Context

This module requires certain minimum node version, but it's not always clear and will error out if an outdated node version is used.

## Objective

This PR adds minimum node versions to `engines` in `package.json`. Also updated screwdriver.yaml to use `node:14`.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2687
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
