### PR TITLE
fix: Use latest semantic-release template

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,7 +11,7 @@ jobs:
             - test: npm test
     publish:
         requires: main
-        template: screwdriver-cd/semantic-release@1.0.2
+        template: screwdriver-cd/semantic-release
         secrets:
             # Publishing to NPM
             - NPM_TOKEN


### PR DESCRIPTION
## Context

Semantic release failed for template-main. https://cd.screwdriver.cd/pipelines/493/builds/781019/steps/publish

## Objective

This PR updates screwdriver.yaml to use latest semantic-release template. It was previously pinned to support node:6 (https://github.com/screwdriver-cd/template-main/pull/17).

## References
N/A

## License


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
