### PR TITLE
feat(2862): Delete a specific version of a template

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ ./node_modules/.bin/template-remove --json --name templateName
 ### Removing a template version
 
 To remove a specific version of a template, run the `template-remove-version` binary. This must be done in the same pipeline that published the template. You'll need to specify the template name and version as arguments.
-Removing a template version, will remove all the tags associated with it.
+Removing a template version will remove all the tags associated with it.
 
 Example `screwdriver.yaml` with validation, publishing and tagging, and version removal as a detached job:
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,35 @@ $ ./node_modules/.bin/template-remove --json --name templateName
 {"name":"templateName"}
 ```
 
+### Removing a template version
+
+To remove a specific version of a template, run the `template-remove-version` binary. This must be done in the same pipeline that published the template. You'll need to specify the template name and version as arguments.
+Removing a template version, will remove all the tags associated with it.
+
+Example `screwdriver.yaml` with validation, publishing and tagging, and version removal as a detached job:
+
+```yaml
+shared:
+    image: node:6
+    steps:
+        - init: npm install screwdriver-template-main
+jobs:
+    main:
+        requires: [~pr, ~commit]
+        steps:
+            - validate: ./node_modules/.bin/template-validate
+    publish:
+        requires: main
+        steps:
+            - publish: ./node_modules/.bin/template-publish
+            - tag: ./node_modules/.bin/template-tag --name templateName --version 1.0.0 --tag latest
+    detached_remove_version:
+        steps:
+            - remove: ./node_modules/.bin/template-remove-version --name templateName --version 1.0.0
+```
+
+`template-remove-tag` can print a result as json by passing `--json` option to the command.
+
 ### Tagging a template
 
 Optionally, tag a template using the `template-tag` script. This must be done in the same pipeline that published the template. You'll need to add arguments for the template name and tag. You can optionally specify a version; the version must be an exact version, not just a major or major.minor one. If omitted, the latest version will be tagged.

--- a/bin/removeVersion.js
+++ b/bin/removeVersion.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('../commands').run('remove_version');

--- a/commands.js
+++ b/commands.js
@@ -125,6 +125,35 @@ const operations = {
         help: 'remove tag'
     },
 
+    /* Remove template version */
+    remove_version: {
+        opts: {
+            name: { required: true, abbr: 'n', help: 'Template name' },
+            version: { abbr: 'v', required: true, help: 'Version' },
+            json: { abbr: 'j', flag: true, help: 'Output result as json' }
+        },
+
+        exec(opts) {
+            return index
+                .removeVersion({
+                    name: opts.name,
+                    version: opts.version
+                })
+                .then(result => {
+                    if (!opts.json) {
+                        console.log(`Version ${opts.version} was successfully removed from ${opts.name}`);
+                    } else {
+                        console.log(JSON.stringify(result));
+                    }
+                })
+                .catch(err => {
+                    console.error(err);
+                    process.exit(1);
+                });
+        },
+        help: 'remove version'
+    },
+
     /* remove a template */
     remove_template: {
         opts: {

--- a/index.js
+++ b/index.js
@@ -126,6 +126,39 @@ function removeTemplate(name) {
 }
 
 /**
+ * Removes specified version of a template by sending a delete request to the SDAPI /templates/{name}/versions/{version} endpoint
+ * @method removeTemplate
+ * @param  {Object}    config
+ * @param  {String}    config.name    Template name
+ * @param  {String}    config.version Template version to be removed
+ * @return {Promise}                  Resolves if removed successfully
+ */
+function removeVersion({ name, version }) {
+    const hostname = process.env.SD_API_URL || 'https://api.screwdriver.cd/v4/';
+    const templateName = encodeURIComponent(name);
+    const templateVersion = encodeURIComponent(version);
+    const url = URL.resolve(hostname, `templates/${templateName}/versions/${templateVersion}`);
+
+    return request({
+        method: 'DELETE',
+        url,
+        context: {
+            token: process.env.SD_TOKEN
+        }
+    }).then(response => {
+        const { body } = response;
+
+        if (response.statusCode !== 204) {
+            throw new Error(
+                `Error removing version ${version} of template ${name}. ${response.statusCode} (${body.error}): ${body.message}`
+            );
+        }
+
+        return { name, version };
+    });
+}
+
+/**
  * Helper function that returns the latest version for a template
  * @method getLatestVersion
  * @param  {String}         name        Template name
@@ -264,6 +297,7 @@ module.exports = {
     validateTemplate,
     publishTemplate,
     removeTemplate,
+    removeVersion,
     tagTemplate,
     removeTag,
     getVersionFromTag

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "template-remove": "./bin/remove.js",
     "template-tag": "./bin/tag.js",
     "template-remove-tag": "./bin/removeTag.js",
+    "template-remove-version": "./bin/removeVersion.js",
     "template-get-version-from-tag": "./bin/getVersionFromTag.js"
   },
   "repository": {
@@ -31,6 +32,7 @@
   "contributors": [
     "Dao Lam <daolam112@gmail.com>",
     "Darren Matsumoto <aeneascorrupt@gmail.com>",
+    "Dayanand Sagar <sagar1312@gmail.com>",
     "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",
     "Jerry Zhang <thejerryzhang@gmail.com>",
     "Min Zhang <minzhang@andrew.cmu.edu>",


### PR DESCRIPTION
## Context

You can remove a templates using `template-remove` binary, which removes all the versions of the template and all of its associated tags.

There could be an use case where template owner published a new version and later realized that there are some issues with it and prevent any jobs from using it.

There is no provision to delete a specific version of a template. 

## Objective

Add a new binary to delete a specific version of a template and all the tags associated with it.
This binary uses the new API that was added in this PR https://github.com/screwdriver-cd/screwdriver/pull/2863

Usage:
```shell
$ ./node_modules/.bin/template-remove-version --name template_name --version template_version
``` 

## References

https://github.com/screwdriver-cd/screwdriver/issues/2862

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
