### PR TITLE
feat(2135): Add new commands to validate and publish pipeline level template

### DIFF
--- a/bin/pipelineTemplatePublish.js
+++ b/bin/pipelineTemplatePublish.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('../commands').run('publishPipelineTemplate');

--- a/bin/pipelineTemplateValidate.js
+++ b/bin/pipelineTemplateValidate.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('../commands').run('validatePipelineTemplate');

--- a/bin/pipelineValidate.js
+++ b/bin/pipelineValidate.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('../commands').run('pipelineValidate');

--- a/bin/pipelineValidate.js
+++ b/bin/pipelineValidate.js
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-
-'use strict';
-
-require('../commands').run('pipelineValidate');

--- a/commands.js
+++ b/commands.js
@@ -26,7 +26,7 @@ const operations = {
                     if (!opts.json) {
                         console.log(
                             `Template ${result.name}@${result.version} was ` +
-                                `successfully published and tagged as ${result.tag}`
+                            `successfully published and tagged as ${result.tag}`
                         );
                     } else {
                         console.log(JSON.stringify(result));
@@ -201,6 +201,29 @@ const operations = {
                 });
         },
         help: 'get version from tag'
+    },
+
+    pipelineValidate: {
+        opts: {
+            json: { abbr: 'j', flag: true, help: 'Output result as json' }
+        },
+        exec(opts) {
+            return index
+                .loadYaml(path)
+                .then(config => index.validatePipelineTemplate(config))
+                .then(result => {
+                    if (!opts.json) {
+                        console.log('Template is valid');
+                    } else {
+                        console.log(JSON.stringify(result));
+                    }
+                })
+                .catch(err => {
+                    console.error(err);
+                    process.exit(1);
+                });
+        },
+        help: 'validate template'
     }
 };
 

--- a/commands.js
+++ b/commands.js
@@ -26,7 +26,7 @@ const operations = {
                     if (!opts.json) {
                         console.log(
                             `Template ${result.name}@${result.version} was ` +
-                            `successfully published and tagged as ${result.tag}`
+                                `successfully published and tagged as ${result.tag}`
                         );
                     } else {
                         console.log(JSON.stringify(result));
@@ -48,7 +48,7 @@ const operations = {
         exec(opts) {
             return index
                 .loadYaml(path)
-                .then(config => index.validateTemplate(config))
+                .then(config => index.validateJobTemplate(config))
                 .then(result => {
                     if (!opts.json) {
                         console.log('Template is valid');
@@ -203,7 +203,7 @@ const operations = {
         help: 'get version from tag'
     },
 
-    pipelineValidate: {
+    validatePipelineTemplate: {
         opts: {
             json: { abbr: 'j', flag: true, help: 'Output result as json' }
         },
@@ -223,15 +223,49 @@ const operations = {
                     process.exit(1);
                 });
         },
-        help: 'validate template'
+        help: 'validate pipeline template'
+    },
+
+    publishPipelineTemplate: {
+        opts: {
+            json: { abbr: 'j', flag: true, help: 'Output result as json' },
+            tag: { abbr: 't', default: 'latest', help: 'Add template tag' }
+        },
+        exec(opts) {
+            return index
+                .loadYaml(path)
+                .then(config => index.publishPipelineTemplate(config))
+                .then(publishResult =>
+                    index.tagTemplate({
+                        name: publishResult.name,
+                        tag: opts.tag,
+                        version: publishResult.version
+                    })
+                )
+                .then(result => {
+                    if (!opts.json) {
+                        console.log(
+                            `Pipeline template ${result.name}@${result.version} was ` +
+                                `successfully published and tagged as ${result.tag}`
+                        );
+                    } else {
+                        console.log(JSON.stringify(result));
+                    }
+                })
+                .catch(err => {
+                    console.error(err);
+                    process.exit(1);
+                });
+        },
+        help: 'publish pipeline template'
     }
 };
 
 /**
  * Execute the given command by name.
  * @method run
- * @param  {String}    command name
  * @return {Object}    result of command, if any
+ * @param name
  */
 function run(name) {
     const opts = nomnom.options(operations[name].opts).help(operations[name].help).parse();

--- a/commands.js
+++ b/commands.js
@@ -5,7 +5,7 @@ const index = require('./index');
 const path = process.env.SD_TEMPLATE_PATH || './sd-template.yaml';
 
 const operations = {
-    /* Publish template */
+    /* Publish job template */
     publish: {
         opts: {
             json: { abbr: 'j', flag: true, help: 'Output result as json' },
@@ -14,7 +14,7 @@ const operations = {
         exec(opts) {
             return index
                 .loadYaml(path)
-                .then(config => index.publishTemplate(config))
+                .then(config => index.publishJobTemplate(config))
                 .then(publishResult =>
                     index.tagTemplate({
                         name: publishResult.name,
@@ -40,7 +40,7 @@ const operations = {
         help: 'publish template'
     },
 
-    /* Validate template */
+    /* Validate job template */
     validate: {
         opts: {
             json: { abbr: 'j', flag: true, help: 'Output result as json' }
@@ -203,6 +203,7 @@ const operations = {
         help: 'get version from tag'
     },
 
+    /* Validate pipeline template */
     validatePipelineTemplate: {
         opts: {
             json: { abbr: 'j', flag: true, help: 'Output result as json' }
@@ -226,28 +227,18 @@ const operations = {
         help: 'validate pipeline template'
     },
 
+    /* Publish pipeline template */
     publishPipelineTemplate: {
         opts: {
-            json: { abbr: 'j', flag: true, help: 'Output result as json' },
-            tag: { abbr: 't', default: 'latest', help: 'Add template tag' }
+            json: { abbr: 'j', flag: true, help: 'Output result as json' }
         },
         exec(opts) {
             return index
                 .loadYaml(path)
                 .then(config => index.publishPipelineTemplate(config))
-                .then(publishResult =>
-                    index.tagTemplate({
-                        name: publishResult.name,
-                        tag: opts.tag,
-                        version: publishResult.version
-                    })
-                )
                 .then(result => {
                     if (!opts.json) {
-                        console.log(
-                            `Pipeline template ${result.name}@${result.version} was ` +
-                                `successfully published and tagged as ${result.tag}`
-                        );
+                        console.log(`Pipeline template ${result.name}@${result.version} was successfully published`);
                     } else {
                         console.log(JSON.stringify(result));
                     }
@@ -264,8 +255,8 @@ const operations = {
 /**
  * Execute the given command by name.
  * @method run
+ * @param  {String}    command name
  * @return {Object}    result of command, if any
- * @param name
  */
 function run(name) {
     const opts = nomnom.options(operations[name].opts).help(operations[name].help).parse();

--- a/commands.js
+++ b/commands.js
@@ -64,7 +64,7 @@ const operations = {
         help: 'validate template'
     },
 
-    /* Add tag for template */
+    /* Add tag for job template */
     tag: {
         opts: {
             name: { required: true, abbr: 'n', help: 'Template name' },
@@ -96,7 +96,7 @@ const operations = {
         help: 'add tag'
     },
 
-    /* Remove tag for template */
+    /* Remove tag for job template */
     remove_tag: {
         opts: {
             name: { required: true, abbr: 'n', help: 'Template name' },
@@ -125,7 +125,7 @@ const operations = {
         help: 'remove tag'
     },
 
-    /* Remove template version */
+    /* Remove job template version */
     remove_version: {
         opts: {
             name: { required: true, abbr: 'n', help: 'Template name' },
@@ -154,7 +154,7 @@ const operations = {
         help: 'remove version'
     },
 
-    /* remove a template */
+    /* remove a job template */
     remove_template: {
         opts: {
             name: { required: true, abbr: 'n', help: 'Template name' },
@@ -179,7 +179,7 @@ const operations = {
         help: 'remove template'
     },
 
-    /* get version number from tag */
+    /* get job template version number from tag */
     get_version_from_tag: {
         opts: {
             name: { required: true, abbr: 'n', help: 'Template name' },

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function loadYaml(path) {
  */
 function validateTemplate(config) {
     const hostname = process.env.SD_API_URL || 'https://api.screwdriver.cd/v4/';
-    const url = URL.resolve(hostname, 'validator/template');
+    const url = URL.resolve(hostname, 'validator/template'); /* sd -> template-validator.js */
 
     return request({
         method: 'POST',
@@ -292,6 +292,41 @@ function removeTag({ name, tag }) {
         };
     });
 }
+
+function validatePipelineTemplate(config) {
+    const hostname = process.env.SD_API_URL || 'https://api.screwdriver.cd/v4/';
+    const url = URL.resolve(hostname, 'pipeline/template/validate'); /* sd -> template-validator.js */
+
+    return request({
+        method: 'POST',
+        url,
+        context: {
+            token: process.env.SD_TOKEN
+        },
+        json: {
+            yaml: JSON.stringify(config)
+        }
+    }).then(response => {
+        const { body } = response;
+
+        if (body.errors.length > 0) {
+            let errorMessage = 'Template is not valid for the following reasons:';
+
+            body.errors.forEach(err => {
+                /* eslint-disable prefer-template */
+                errorMessage += `\n${JSON.stringify(err, null, 4)},`;
+                /* eslint-enable prefer-template */
+            });
+
+            throw new Error(errorMessage);
+        }
+
+        return {
+            valid: true
+        };
+    });
+}
+
 module.exports = {
     loadYaml,
     validateTemplate,
@@ -300,5 +335,6 @@ module.exports = {
     removeVersion,
     tagTemplate,
     removeTag,
-    getVersionFromTag
+    getVersionFromTag,
+    validatePipelineTemplate
 };

--- a/index.js
+++ b/index.js
@@ -103,10 +103,7 @@ function publishTemplate(config, apiURL) {
             throw new Error(`Error publishing template. ${response.statusCode} (${body.error}): ${body.message}`);
         }
 
-        return {
-            name: body.name,
-            version: body.version
-        };
+        return body;
     });
 }
 
@@ -117,7 +114,19 @@ function publishTemplate(config, apiURL) {
  * @return {Promise}        Resolves if publishes successfully
  */
 function publishJobTemplate(config) {
-    return publishTemplate(config, 'templates');
+    return publishTemplate(config, 'templates').then(template => {
+        let fullTemplateName = template.name;
+
+        // Figure out template name
+        if (template.namespace && template.namespace !== 'default') {
+            fullTemplateName = `${template.namespace}/${template.name}`;
+        }
+
+        return {
+            name: fullTemplateName,
+            version: template.version
+        };
+    });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,70 +1,69 @@
 {
-    "name": "screwdriver-template-main",
-    "version": "2.0.0",
-    "description": "Validates, publishes, and tags templates",
-    "main": "index.js",
-    "scripts": {
-        "pretest": "eslint .",
-        "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true"
-    },
-    "bin": {
-        "sd-template-tool": "./bin/main.js",
-        "template-publish": "./bin/publish.js",
-        "template-validate": "./bin/validate.js",
-        "template-remove": "./bin/remove.js",
-        "template-tag": "./bin/tag.js",
-        "template-remove-tag": "./bin/removeTag.js",
-        "template-remove-version": "./bin/removeVersion.js",
-        "template-get-version-from-tag": "./bin/getVersionFromTag.js",
-        "pipeline-template-validate": "./bin/pipelineTemplateValidate.js",
-        "pipeline-template-publish": "./bin/pipelineTemplatePublish.js"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/screwdriver-cd/template-main.git"
-    },
-    "homepage": "https://github.com/screwdriver-cd/template-main",
-    "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
-    "keywords": [
-        "screwdriver",
-        "yahoo"
-    ],
-    "license": "BSD-3-Clause",
-    "author": "Tiffany Kyi <tiffanykyi@gmail.com>",
-    "contributors": [
-        "Dao Lam <daolam112@gmail.com>",
-        "Darren Matsumoto <aeneascorrupt@gmail.com>",
-        "Dayanand Sagar <sagar1312@gmail.com>",
-        "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",
-        "Jerry Zhang <thejerryzhang@gmail.com>",
-        "Min Zhang <minzhang@andrew.cmu.edu>",
-        "Peter Peterson <jedipetey@gmail.com>",
-        "Philip Scott <pscott@zeptohost.com>",
-        "Reetika Rastogi <r3rastogi@gmail.com>",
-        "St. John Johnson <st.john.johnson@gmail.com>",
-        "Tiffany Kyi <tiffanykyi@gmail.com>"
-    ],
-    "devDependencies": {
-        "chai": "^4.3.7",
-        "eslint": "^8.28.0",
-        "eslint-config-screwdriver": "^7.0.0",
-        "mocha": "^10.1.0",
-        "mocha-multi-reporters": "^1.5.1",
-        "mocha-sonarqube-reporter": "^1.0.2",
-        "mockery": "^2.1.0",
-        "nyc": "^15.1.0",
-        "sinon": "^15.0.0"
-    },
-    "dependencies": {
-        "js-yaml": "^4.1.0",
-        "jsdoc": "^4.0.2",
-        "nomnom": "^1.8.1",
-        "screwdriver-request": "^2.0.1"
-    },
-    "release": {
-        "debug": false
-    },
-    "engines": {
-        "node": ">=18.0.0"
-    }
+  "name": "screwdriver-template-main",
+  "version": "2.0.0",
+  "description": "Validates, publishes, and tags templates",
+  "main": "index.js",
+  "scripts": {
+    "pretest": "eslint .",
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true"
+  },
+  "bin": {
+    "sd-template-tool": "./bin/main.js",
+    "template-publish": "./bin/publish.js",
+    "template-validate": "./bin/validate.js",
+    "template-remove": "./bin/remove.js",
+    "template-tag": "./bin/tag.js",
+    "template-remove-tag": "./bin/removeTag.js",
+    "template-remove-version": "./bin/removeVersion.js",
+    "template-get-version-from-tag": "./bin/getVersionFromTag.js",
+    "pipeline-template-validate": "./bin/pipelineTemplateValidate.js",
+    "pipeline-template-publish": "./bin/pipelineTemplatePublish.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/screwdriver-cd/template-main.git"
+  },
+  "homepage": "https://github.com/screwdriver-cd/template-main",
+  "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
+  "keywords": [
+    "screwdriver",
+    "yahoo"
+  ],
+  "license": "BSD-3-Clause",
+  "author": "Tiffany Kyi <tiffanykyi@gmail.com>",
+  "contributors": [
+    "Dao Lam <daolam112@gmail.com>",
+    "Darren Matsumoto <aeneascorrupt@gmail.com>",
+    "Dayanand Sagar <sagar1312@gmail.com>",
+    "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",
+    "Jerry Zhang <thejerryzhang@gmail.com>",
+    "Min Zhang <minzhang@andrew.cmu.edu>",
+    "Peter Peterson <jedipetey@gmail.com>",
+    "Philip Scott <pscott@zeptohost.com>",
+    "Reetika Rastogi <r3rastogi@gmail.com>",
+    "St. John Johnson <st.john.johnson@gmail.com>",
+    "Tiffany Kyi <tiffanykyi@gmail.com>"
+  ],
+  "devDependencies": {
+    "chai": "^4.3.7",
+    "eslint": "^8.28.0",
+    "eslint-config-screwdriver": "^7.0.0",
+    "mocha": "^10.1.0",
+    "mocha-multi-reporters": "^1.5.1",
+    "mocha-sonarqube-reporter": "^1.0.2",
+    "mockery": "^2.1.0",
+    "nyc": "^15.1.0",
+    "sinon": "^15.0.0"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0",
+    "nomnom": "^1.8.1",
+    "screwdriver-request": "^2.0.1"
+  },
+  "release": {
+    "debug": false
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "template-remove-tag": "./bin/removeTag.js",
         "template-remove-version": "./bin/removeVersion.js",
         "template-get-version-from-tag": "./bin/getVersionFromTag.js",
-        "pipeline-template-validate": "./bin/pipelineValidate.js"
+        "pipeline-template-validate": "./bin/pipelineTemplateValidate.js",
+        "pipeline-template-publish": "./bin/pipelineTemplatePublish.js"
     },
     "repository": {
         "type": "git",
@@ -56,6 +57,7 @@
     },
     "dependencies": {
         "js-yaml": "^4.1.0",
+        "jsdoc": "^4.0.2",
         "nomnom": "^1.8.1",
         "screwdriver-request": "^2.0.1"
     },

--- a/package.json
+++ b/package.json
@@ -1,67 +1,68 @@
 {
-  "name": "screwdriver-template-main",
-  "version": "2.0.0",
-  "description": "Validates, publishes, and tags templates",
-  "main": "index.js",
-  "scripts": {
-    "pretest": "eslint .",
-    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true"
-  },
-  "bin": {
-    "sd-template-tool": "./bin/main.js",
-    "template-publish": "./bin/publish.js",
-    "template-validate": "./bin/validate.js",
-    "template-remove": "./bin/remove.js",
-    "template-tag": "./bin/tag.js",
-    "template-remove-tag": "./bin/removeTag.js",
-    "template-remove-version": "./bin/removeVersion.js",
-    "template-get-version-from-tag": "./bin/getVersionFromTag.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/screwdriver-cd/template-main.git"
-  },
-  "homepage": "https://github.com/screwdriver-cd/template-main",
-  "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
-  "keywords": [
-    "screwdriver",
-    "yahoo"
-  ],
-  "license": "BSD-3-Clause",
-  "author": "Tiffany Kyi <tiffanykyi@gmail.com>",
-  "contributors": [
-    "Dao Lam <daolam112@gmail.com>",
-    "Darren Matsumoto <aeneascorrupt@gmail.com>",
-    "Dayanand Sagar <sagar1312@gmail.com>",
-    "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",
-    "Jerry Zhang <thejerryzhang@gmail.com>",
-    "Min Zhang <minzhang@andrew.cmu.edu>",
-    "Peter Peterson <jedipetey@gmail.com>",
-    "Philip Scott <pscott@zeptohost.com>",
-    "Reetika Rastogi <r3rastogi@gmail.com>",
-    "St. John Johnson <st.john.johnson@gmail.com>",
-    "Tiffany Kyi <tiffanykyi@gmail.com>"
-  ],
-  "devDependencies": {
-    "chai": "^4.3.7",
-    "eslint": "^8.28.0",
-    "eslint-config-screwdriver": "^7.0.0",
-    "mocha": "^10.1.0",
-    "mocha-multi-reporters": "^1.5.1",
-    "mocha-sonarqube-reporter": "^1.0.2",
-    "mockery": "^2.1.0",
-    "nyc": "^15.1.0",
-    "sinon": "^15.0.0"
-  },
-  "dependencies": {
-    "js-yaml": "^4.1.0",
-    "nomnom": "^1.8.1",
-    "screwdriver-request": "^2.0.1"
-  },
-  "release": {
-    "debug": false
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  }
+    "name": "screwdriver-template-main",
+    "version": "2.0.0",
+    "description": "Validates, publishes, and tags templates",
+    "main": "index.js",
+    "scripts": {
+        "pretest": "eslint .",
+        "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true"
+    },
+    "bin": {
+        "sd-template-tool": "./bin/main.js",
+        "template-publish": "./bin/publish.js",
+        "template-validate": "./bin/validate.js",
+        "template-remove": "./bin/remove.js",
+        "template-tag": "./bin/tag.js",
+        "template-remove-tag": "./bin/removeTag.js",
+        "template-remove-version": "./bin/removeVersion.js",
+        "template-get-version-from-tag": "./bin/getVersionFromTag.js",
+        "pipeline-template-validate": "./bin/pipelineValidate.js"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/screwdriver-cd/template-main.git"
+    },
+    "homepage": "https://github.com/screwdriver-cd/template-main",
+    "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
+    "keywords": [
+        "screwdriver",
+        "yahoo"
+    ],
+    "license": "BSD-3-Clause",
+    "author": "Tiffany Kyi <tiffanykyi@gmail.com>",
+    "contributors": [
+        "Dao Lam <daolam112@gmail.com>",
+        "Darren Matsumoto <aeneascorrupt@gmail.com>",
+        "Dayanand Sagar <sagar1312@gmail.com>",
+        "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",
+        "Jerry Zhang <thejerryzhang@gmail.com>",
+        "Min Zhang <minzhang@andrew.cmu.edu>",
+        "Peter Peterson <jedipetey@gmail.com>",
+        "Philip Scott <pscott@zeptohost.com>",
+        "Reetika Rastogi <r3rastogi@gmail.com>",
+        "St. John Johnson <st.john.johnson@gmail.com>",
+        "Tiffany Kyi <tiffanykyi@gmail.com>"
+    ],
+    "devDependencies": {
+        "chai": "^4.3.7",
+        "eslint": "^8.28.0",
+        "eslint-config-screwdriver": "^7.0.0",
+        "mocha": "^10.1.0",
+        "mocha-multi-reporters": "^1.5.1",
+        "mocha-sonarqube-reporter": "^1.0.2",
+        "mockery": "^2.1.0",
+        "nyc": "^15.1.0",
+        "sinon": "^15.0.0"
+    },
+    "dependencies": {
+        "js-yaml": "^4.1.0",
+        "nomnom": "^1.8.1",
+        "screwdriver-request": "^2.0.1"
+    },
+    "release": {
+        "debug": false
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -72,7 +72,7 @@ describe('index', () => {
             requestMock.rejects(new Error('error'));
 
             return index
-                .validateTemplate(templateConfig)
+                .validateJobTemplate(templateConfig)
                 .then(() => assert.fail('should not get here'))
                 .catch(err => {
                     assert.equal(err.message, 'error');
@@ -99,7 +99,7 @@ describe('index', () => {
             requestMock.resolves(responseFake);
 
             return index
-                .validateTemplate(templateConfig)
+                .validateJobTemplate(templateConfig)
                 .then(() => assert.fail('should not get here'))
                 .catch(err => {
                     // eslint-disable-next-line max-len
@@ -124,7 +124,7 @@ describe('index', () => {
 
             requestMock.resolves(responseFake);
 
-            return index.validateTemplate(templateConfig).then(result =>
+            return index.validateJobTemplate(templateConfig).then(result =>
                 assert.deepEqual(result, {
                     valid: true
                 })
@@ -137,7 +137,7 @@ describe('index', () => {
             requestMock.rejects(new Error('error'));
 
             return index
-                .publishTemplate(templateConfig)
+                .publishJobTemplate(templateConfig)
                 .then(() => assert.fail('should not get here'))
                 .catch(err => {
                     assert.equal(err.message, 'error');
@@ -157,7 +157,7 @@ describe('index', () => {
             requestMock.resolves(responseFake);
 
             return index
-                .publishTemplate(templateConfig)
+                .publishJobTemplate(templateConfig)
                 .then(() => assert.fail('should not get here'))
                 .catch(err => {
                     assert.equal(err.message, 'Error publishing template. 403 (Forbidden): Fake forbidden message');
@@ -172,7 +172,7 @@ describe('index', () => {
 
             requestMock.resolves(responseFake);
 
-            return index.publishTemplate(templateConfig).then(result =>
+            return index.publishJobTemplate(templateConfig).then(result =>
                 assert.deepEqual(result, {
                     name: templateConfig.name,
                     version: templateConfig.version
@@ -189,7 +189,7 @@ describe('index', () => {
             templateConfig.namespace = 'meow';
             requestMock.resolves(responseFake);
 
-            return index.publishTemplate(templateConfig).then(result =>
+            return index.publishJobTemplate(templateConfig).then(result =>
                 assert.deepEqual(result, {
                     name: `${templateConfig.namespace}/${templateConfig.name}`,
                     version: templateConfig.version
@@ -206,7 +206,7 @@ describe('index', () => {
             templateConfig.namespace = 'default';
             requestMock.resolves(responseFake);
 
-            return index.publishTemplate(templateConfig).then(result =>
+            return index.publishJobTemplate(templateConfig).then(result =>
                 assert.deepEqual(result, {
                     name: templateConfig.name,
                     version: templateConfig.version


### PR DESCRIPTION
## Context

Need new command to validate pipeline templates

## Objective

Below changes have been made:

-added new command `pipeline-template-validate`
-added function `validateTemplate` which is called by `validateJobTemplate` and `validatePipelineTemplate` in index.js
-added new operation `validatePipelineTemplate` in commands.js

## References

https://github.com/screwdriver-cd/screwdriver/issues/2135

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
