### PR TITLE
fix(2135): correcting the endpoint URL for publish pipeline template

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ function publishJobTemplate(config) {
  * @return {Promise}        Resolves if publishes successfully
  */
 function publishPipelineTemplate(config) {
-    return publishTemplate(config, 'pipeline/template/publish');
+    return publishTemplate(config, 'pipelineTemplates');
 }
 
 /**


### PR DESCRIPTION
## Context

https://github.com/screwdriver-cd/template-main/pull/38
The command to publish pipeline template in the above PR is pointing to a wrong API endpoint `pipeline/template/publish`

## Objective

Updating the endpoint to `pipelineTemplates`

## References

https://github.com/screwdriver-cd/screwdriver/issues/2135

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
