### PR TITLE
feat: tag template after publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,62 @@ jobs:
         steps:
             - get_version: ./node_modules/.bin/template-get-version-from-tag --name templateName --tag latest
 ```
+## Pipeline Templates
+
+### Validating a template
+
+Run the `pipeline-template-validate` script. By default, the path `./sd-template.yaml` will be read. However, a user can specify a custom path using the env variable: `SD_TEMPLATE_PATH`.
+
+Example `screwdriver.yaml`:
+
+```yaml
+shared:
+    image: node:6
+jobs:
+    main:
+        requires: [~pr, ~commit]
+        steps:
+            - install: npm install screwdriver-template-main
+            - validate: ./node_modules/.bin/pipeline-template-validate
+        environment:
+            SD_TEMPLATE_PATH: ./path/to/pipeline-template.yaml
+```
+
+`pipeline-template-validate` can print a result as json by passing `--json` option to the command.
+
+```
+$ ./node_modules/.bin/pipeline-template-validate --json
+{"valid":true}
+```
+
+### Publishing a pipeline template
+
+Run the `pipeline-template-publish` script. By default, the path `./sd-template.yaml` will be read. However, a user can specify a custom path using the env variable: `SD_TEMPLATE_PATH`.
+
+Example `screwdriver.yaml` with validation and publishing:
+
+```yaml
+shared:
+    image: node:6
+jobs:
+    main:
+        requires: [~pr, ~commit]
+        steps:
+            - install: npm install screwdriver-template-main
+            - validate: ./node_modules/.bin/pipeline-template-validate
+    publish:
+        requires: main
+        steps:
+            - install: npm install screwdriver-template-main
+            - publish: ./node_modules/.bin/pipeline-template-publish --tag stable
+```
+
+`pipeline-template-publish` can print a result as json by passing `--json` option to the command. `pipeline-template-publish` will tag the published version as well. The default tag is `latest` if none is specified.
+
+```
+$ ./node_modules/.bin/pipeline-template-publish --json
+{namespace:"template", name:"foo",version:"1.2.3",tag:"stable"}
+```
 
 ## Testing
 

--- a/bin/pipelineTemplatePublish.js
+++ b/bin/pipelineTemplatePublish.js
@@ -2,4 +2,4 @@
 
 'use strict';
 
-require('../commands').run('publishPipelineTemplate');
+require('../commands').run('publish_pipeline_template');

--- a/bin/pipelineTemplateValidate.js
+++ b/bin/pipelineTemplateValidate.js
@@ -2,4 +2,4 @@
 
 'use strict';
 
-require('../commands').run('validatePipelineTemplate');
+require('../commands').run('validate_pipeline_template');

--- a/commands.js
+++ b/commands.js
@@ -16,7 +16,7 @@ const operations = {
                 .loadYaml(path)
                 .then(config => index.publishJobTemplate(config))
                 .then(publishResult =>
-                    index.tagTemplate({
+                    index.tagJobTemplate({
                         name: publishResult.name,
                         tag: opts.tag,
                         version: publishResult.version
@@ -74,7 +74,7 @@ const operations = {
         },
         exec(opts) {
             return index
-                .tagTemplate({
+                .tagJobTemplate({
                     name: opts.name,
                     tag: opts.tag,
                     version: opts.version
@@ -204,7 +204,7 @@ const operations = {
     },
 
     /* Validate pipeline template */
-    validatePipelineTemplate: {
+    validate_pipeline_template: {
         opts: {
             json: { abbr: 'j', flag: true, help: 'Output result as json' }
         },
@@ -228,7 +228,7 @@ const operations = {
     },
 
     /* Publish pipeline template */
-    publishPipelineTemplate: {
+    publish_pipeline_template: {
         opts: {
             json: { abbr: 'j', flag: true, help: 'Output result as json' }
         },
@@ -236,9 +236,19 @@ const operations = {
             return index
                 .loadYaml(path)
                 .then(config => index.publishPipelineTemplate(config))
+                .then(publishResult =>
+                    index.tagPipelineTemplate({
+                        name: publishResult.name,
+                        namespace: publishResult.namespace,
+                        tag: opts.tag,
+                        version: publishResult.version
+                    })
+                )
                 .then(result => {
                     if (!opts.json) {
-                        console.log(`Pipeline template ${result.name}@${result.version} was successfully published`);
+                        console.log(
+                            `Pipeline template ${result.name}@${result.version} was successfully published and tagged as ${result.tag}`
+                        );
                     } else {
                         console.log(JSON.stringify(result));
                     }

--- a/commands.js
+++ b/commands.js
@@ -230,7 +230,8 @@ const operations = {
     /* Publish pipeline template */
     publish_pipeline_template: {
         opts: {
-            json: { abbr: 'j', flag: true, help: 'Output result as json' }
+            json: { abbr: 'j', flag: true, help: 'Output result as json' },
+            tag: { abbr: 't', default: 'latest', help: 'Add template tag' }
         },
         exec(opts) {
             return index


### PR DESCRIPTION
## Context

Tag a pipeline template after publish

## Objective

This PR adds a function to tag a pipeline template, and also fixes the validate pipeline template endpoint 

## References

https://github.com/screwdriver-cd/screwdriver/issues/2135

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
